### PR TITLE
Keep x builds after deploy.

### DIFF
--- a/deploy/50-cleanup/10-clear-old-builds.sh
+++ b/deploy/50-cleanup/10-clear-old-builds.sh
@@ -12,12 +12,20 @@ if [ -f "${BUILD_ID}.tar.gz" ]; then
     rm -f "${BUILD_ID}.tar.gz"
 fi
 
-PREVIOUS=`expr ${BUILD} - 1`
-shopt -s nullglob
-for FILE in ${RELEASE_PARENT_DIR}/*-*
+NUM=0
+PREVIOUS_BUILDS=2
+for FILE in `ls -d -- ${RELEASE_PARENT_DIR}/*-* | sort -t- -k2 -r`
 do
-    if [[ ${FILE} != *"-${BUILD}"* ]] && [[ ${FILE} != *"-${PREVIOUS}"* ]]; then
-        printf "DELETING ${FILE}\n"
-        rm -rf ${FILE}
+    if [[ ${FILE} != *"-${BUILD}"* ]]; then
+        let "NUM=NUM+1"
+        if [[ $NUM > $PREVIOUS_BUILDS ]]; then
+            printf "DELETING ${FILE}\n"
+            rm -rf ${FILE}
+        else
+            IFS='-' read -ra BUILD_ARR <<< "$FILE"
+            printf "Keeping recent build ${BUILD_ARR[1]}\n"
+        fi
+    else
+        printf "Keeping current build ${BUILD}\n"
     fi
 done


### PR DESCRIPTION
Based on existing code, I made the assumption that there will only be one hyphen in any build name and it will be between the build name and the build number. If this is incorrect, I'll have to change the code accordingly. Also, PREVIOUS_BUILDS can be passed in from CI rather than defined explicitly in the file.