### PR TITLE
Fixed initial issues

### DIFF
--- a/deploy/50-cleanup/10-clear-old-builds.sh
+++ b/deploy/50-cleanup/10-clear-old-builds.sh
@@ -14,16 +14,26 @@ fi
 
 NUM=0
 PREVIOUS_BUILDS=2
-for FILE in `ls -d -- ${RELEASE_PARENT_DIR}/*-* | sort -t- -k2 -r`
+shopt -s nullglob
+for FILE in ${RELEASE_PARENT_DIR}/*-*
 do
+    if [[ ! -d ${FILE} ]]; then
+        continue
+    fi
     if [[ ${FILE} != *"-${BUILD}"* ]]; then
         let "NUM=NUM+1"
+        IFS='-' read -ra BUILD_ARR <<< "$FILE"
+        BUILD_NUM=${BUILD_ARR[@]:(-1)}
+        re='^[0-9]+$'
+        if ! [[ $BUILD_NUM =~ $re ]] ; then
+            printf "${BUILD_NUM} is not numeric\n"
+            #continue
+        fi
         if [[ $NUM > $PREVIOUS_BUILDS ]]; then
             printf "DELETING ${FILE}\n"
-            rm -rf ${FILE}
+            #rm -rf ${FILE}
         else
-            IFS='-' read -ra BUILD_ARR <<< "$FILE"
-            printf "Keeping recent build ${BUILD_ARR[1]}\n"
+            printf "Keeping recent build ${BUILD_NUM}\n"
         fi
     else
         printf "Keeping current build ${BUILD}\n"

--- a/deploy/50-cleanup/10-clear-old-builds.sh
+++ b/deploy/50-cleanup/10-clear-old-builds.sh
@@ -13,7 +13,7 @@ if [ -f "${BUILD_ID}.tar.gz" ]; then
 fi
 
 NUM=0
-PREVIOUS_BUILDS=2
+PREVIOUS_BUILDS=1
 shopt -s nullglob
 for FILE in `ls -d -- ${RELEASE_PARENT_DIR}/*-* | sort -t- -k2 -r`
 do

--- a/deploy/50-cleanup/10-clear-old-builds.sh
+++ b/deploy/50-cleanup/10-clear-old-builds.sh
@@ -45,3 +45,5 @@ do
         printf "Keeping current build ${BUILD}\n"
     fi
 done
+
+rm -rf ${RELEASE_PARENT_DIR}/*.gz

--- a/deploy/50-cleanup/10-clear-old-builds.sh
+++ b/deploy/50-cleanup/10-clear-old-builds.sh
@@ -15,23 +15,29 @@ fi
 NUM=0
 PREVIOUS_BUILDS=2
 shopt -s nullglob
-for FILE in ${RELEASE_PARENT_DIR}/*-*
+for FILE in `ls -d -- ${RELEASE_PARENT_DIR}/*-* | sort -t- -k2 -r`
 do
     if [[ ! -d ${FILE} ]]; then
         continue
     fi
     if [[ ${FILE} != *"-${BUILD}"* ]]; then
-        let "NUM=NUM+1"
-        IFS='-' read -ra BUILD_ARR <<< "$FILE"
-        BUILD_NUM=${BUILD_ARR[@]:(-1)}
+        FILE_BASE=`basename ${FILE}`
+        IFS='-' read -ra BUILD_ARR <<< "$FILE_BASE"
+        BUILD_LABEL=${BUILD_ARR[0]}
+        BUILD_NUM=${BUILD_ARR[1]}
         re='^[0-9]+$'
-        if ! [[ $BUILD_NUM =~ $re ]] ; then
-            printf "${BUILD_NUM} is not numeric\n"
-            #continue
+        if ! [[ $BUILD_NUM =~ $re ]]; then
+            printf "${FILE_BASE} is not a build directory\n"
+            continue
         fi
+        if ! [[ "$BUILD_LABEL" = "build" ]]; then
+            printf "${FILE_BASE} is not a build directory\n"
+            continue
+        fi
+        let "NUM=NUM+1"
         if [[ $NUM > $PREVIOUS_BUILDS ]]; then
             printf "DELETING ${FILE}\n"
-            #rm -rf ${FILE}
+            rm -rf ${FILE}
         else
             printf "Keeping recent build ${BUILD_NUM}\n"
         fi


### PR DESCRIPTION
Improperly named files do not impact previous build folders. A warning is printed, but the folder is not deleted. Generally, such folders won't exist. If they do, they probably require manual investigation.

Keep only 1 previous build.

Delete .gz files