### PR TITLE
Switching to yarn for consistency and fixing syntax

### DIFF
--- a/build/10-pre-process/90-m1-gulp.sh
+++ b/build/10-pre-process/90-m1-gulp.sh
@@ -8,10 +8,10 @@ if [[ ${TESTMODE} == 0 ]] || [[ -z ${TESTMODE+x} ]]; then
             cd ${CHECKOUT_DIR} &&
         
             printf "Installing NPM modules" &&
-            npm install &&
+            yarn install &&
 
             printf "Gulping the files" &&
-            npm run gulp prod
+            yarn run prod
         )
     fi
 fi


### PR DESCRIPTION
`npm run gulp prod` won't work so this moves to running the NPM script.