### PR TITLE
Use "checkout_dir" in both places

### DIFF
--- a/build/20-process/50-npm.sh
+++ b/build/20-process/50-npm.sh
@@ -3,7 +3,7 @@
 ### 50-m2-gulp.sh: this file runs the Snowdog Apps gulp commands
 
 if [ -f "${CHECKOUT_DIR}/package.json" ]; then
-    (cd "${BUILD_DIR}/"  \
+    (cd "${CHECKOUT_DIR}/"  \
         && yarn install \
         && yarn run prod \
     )


### PR DESCRIPTION
I don't understand why the `build_dir` was used for the `package.json`, but since the `package.json` is supposed to be in the root and the `if` was returning true this seems like it could work.
